### PR TITLE
* getl.salesforce.SalesForceDriver: исправлена ошибка в методе bulkUn…

### DIFF
--- a/src/main/groovy/getl/salesforce/SalesForceDataset.groovy
+++ b/src/main/groovy/getl/salesforce/SalesForceDataset.groovy
@@ -17,9 +17,9 @@ class SalesForceDataset extends Dataset {
 	protected void registerParameters() {
 		super.registerParameters()
 
-		methodParams.register('bulkUnload', ['limit', 'where', 'orderBy', 'chunkSize'])
-		methodParams.register('rows', ['limit', 'where', 'readAsBulk', 'orderBy', 'chunkSize'])
-		methodParams.register('eachRow', ['limit', 'where', 'readAsBulk', 'orderBy', 'chunkSize'])
+		methodParams.register('bulkUnload', ['limit', 'where', 'orderBy', 'chunkSize', 'bulkJobId'])
+		methodParams.register('rows', ['limit', 'where', 'readAsBulk', 'orderBy', 'chunkSize', 'bulkJobId'])
+		methodParams.register('eachRow', ['limit', 'where', 'readAsBulk', 'orderBy', 'chunkSize', 'bulkJobId'])
 	}
 
 	@Override


### PR DESCRIPTION
# Getl баги
* getl.salesforce.SalesForceDriver: исправлена ошибка в методе bulkUnload, из-за которой батч, содержащий несколько результатов, обрабатывался неправильно - только последний результат попадал в обработку
* getl.salesforce.SalesForceDriver: исправлена ошибка в методе eachRow, когда неверно обрабатывались поля в prepareCode
# Getl фичи
* getl.salesforce.SalesForceDriver: в методы rows, eachRow, bulkUnload был добавлен параметр bulkJobId, используя который, можно забрать данные с уже завершенной Bulk Job